### PR TITLE
Manually close alert on click / disable auto hide

### DIFF
--- a/bert.js
+++ b/bert.js
@@ -28,7 +28,8 @@ class BertAlert {
     this.defaults = {
       hideDelay: 3500,
       style: 'fixed-top',
-      type: 'default'
+      type: 'default',
+      autoHide: true
     };
   }
 
@@ -59,7 +60,7 @@ class BertAlert {
 
   bertTimer() {
     clearTimeout( this.timer );
-    if(this.defaults.hideDelay > 0) {
+    if(this.hideDelay > 0) {
       this.timer = setTimeout( () => { this.hide(); }, this.defaults.hideDelay );
     }
     return this.timer;
@@ -88,7 +89,8 @@ class BertAlert {
         message: alert[0].message || "",
         type: type,
         style: alert[0].style || this.defaults.style,
-        icon: alert[0].icon || this.icons[ type ]
+        icon: alert[0].icon || this.icons[ type ],
+        hideDelay: alert[0].hideDelay || this.defaults.hideDelay
       });
     } else {
       let type = alert[1] || this.defaults.type;
@@ -97,7 +99,8 @@ class BertAlert {
         message: alert[0] || "",
         type: type,
         style: alert[2] || this.defaults.style,
-        icon: alert[3] || this.icons[ type ]
+        icon: alert[3] || this.icons[ type ],
+        hideDelay: alert[4] || this.defaults.hideDelay
       });
     }
   }

--- a/bert.js
+++ b/bert.js
@@ -59,8 +59,9 @@ class BertAlert {
 
   bertTimer() {
     clearTimeout( this.timer );
-    if(this.hideDelay > 0) {
-      this.timer = setTimeout( () => { this.hide(); }, this.defaults.hideDelay );
+    let currentAlert = Session.get('bertAlert');
+    if(currentAlert.hideDelay > 0) {
+      this.timer = setTimeout( () => { this.hide(); }, currentAlert.hideDelay );
     }
     return this.timer;
   }
@@ -82,7 +83,7 @@ class BertAlert {
   setBertOnSession( alert ) {
     if ( typeof alert[0] === 'object' ) {
       let type = alert[0].type || this.defaults.type;
-
+      console.log(alert[0].hideDelay);
       Session.set( 'bertAlert', {
         title: alert[0].title || "",
         message: alert[0].message || "",

--- a/bert.js
+++ b/bert.js
@@ -28,8 +28,7 @@ class BertAlert {
     this.defaults = {
       hideDelay: 3500,
       style: 'fixed-top',
-      type: 'default',
-      autoHide: true
+      type: 'default'
     };
   }
 

--- a/bert.js
+++ b/bert.js
@@ -59,7 +59,9 @@ class BertAlert {
 
   bertTimer() {
     clearTimeout( this.timer );
-    this.timer = setTimeout( () => { this.hide(); }, this.defaults.hideDelay );
+    if(this.defaults.hideDelay > 0) {
+      this.timer = setTimeout( () => { this.hide(); }, this.defaults.hideDelay );
+    }
     return this.timer;
   }
 


### PR DESCRIPTION
Simply disable the timer when `Bert.defaults.hideDelay = -1` for example.

#41 How can I keep bert alert on screen and manually close it?

Edit : with latest commit also fix #23 #37 #13

You can configure all alerts to be manually closed : 
`Bert.defaults.hideDelay = -1`

or specify an alert to be manually closed by using : 
```
    Bert.alert({
        message:'Event updated !', 
        type:'success', 
        hideDelay: -1
    });
    Bert.alert({
        message:'Event updated !', 
        type:'success', 
        hideDelay: 3000
    });
```

or 

```
Bert.alert('Event updated !', 'success', null, null, -1);
Bert.alert('Event updated !', 'success', null, null, 3000);
```