### PR TITLE
refactor: fourseven:scss to 4.12.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,7 +14,7 @@ Package.onUse( function( api ) {
     'templating',
     'session',
     'jquery',
-    'fourseven:scss@4.10.0',
+    'fourseven:scss@4.12.0',
   ], 'client');
 
   api.addFiles([


### PR DESCRIPTION
I encountered the same issue as described here https://github.com/themeteorchef/bert/issues/56

this change, allow meteorchef:bert to be installed with Meteor 1.10.2