### PR TITLE
FIX:#58 - Bert not working as expected

### DIFF
--- a/bert.js
+++ b/bert.js
@@ -48,7 +48,7 @@ class BertAlert {
   handleAlert( alert ) {
     this.registerClickHandler();
     this.setBertOnSession( alert );
-    setTimeout( () => { this.show(); }, 20 );
+    requestAnimationFrame(() => this.show());
     this.bertTimer();
   }
 
@@ -73,6 +73,7 @@ class BertAlert {
     $( '.bert-alert' ).removeClass( 'animate' );
     setTimeout( () => {
       $( '.bert-alert' ).removeClass( 'show' );
+      $( '.bert-icon').remove();
       Session.set( 'bertAlert', null );
     }, 300 );
   }
@@ -80,22 +81,24 @@ class BertAlert {
   setBertOnSession( alert ) {
     if ( typeof alert[0] === 'object' ) {
       let type = alert[0].type || this.defaults.type;
+      const icon = alert[0].icon || this.icons[ type ];
 
       Session.set( 'bertAlert', {
         title: alert[0].title || "",
         message: alert[0].message || "",
         type: type,
         style: alert[0].style || this.defaults.style,
-        icon: alert[0].icon || this.icons[ type ]
+        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`
       });
     } else {
       let type = alert[1] || this.defaults.type;
+      const icon = alert[3] || this.icons[ type ];
 
       Session.set( 'bertAlert', {
         message: alert[0] || "",
         type: type,
         style: alert[2] || this.defaults.style,
-        icon: alert[3] || this.icons[ type ]
+        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`
       });
     }
   }

--- a/stylesheets/bert.scss
+++ b/stylesheets/bert.scss
@@ -64,7 +64,8 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
   font-size: 14px;
 }
 
-.bert-alert:not(.default) .bert-content > h5 {
+.bert-alert:not(.default) .bert-content > h5,
+.bert-gem {
   color: #fff;
 }
 

--- a/templates/bert-alert.html
+++ b/templates/bert-alert.html
@@ -1,13 +1,15 @@
 <template name="bertAlert">
-  <div class="bert-alert {{alert.style}} {{alert.type}} clearfix">
+  {{#with a=alert}}
+  <div class="bert-alert {{a.style}} {{a.type}} clearfix">
     <div class="bert-container">
       <div class="bert-gem">
-        <i class="{{alert.icon}}"></i>
+        {{{a.icon}}}
       </div>
       <div class="bert-content">
-        {{#if alert.title}}<h5>{{alert.title}}</h5>{{/if}}
-        <p>{{{alert.message}}}</p>
+        {{#if a.title}}<h5>{{a.title}}</h5>{{/if}}
+        <p>{{{a.message}}}</p>
       </div>
     </div>
   </div>
+  {{/with}}
 </template>


### PR DESCRIPTION
Fixes #58.

This PR fixes 2 issues, plus some bonus improvements.

1. Fix the way the icons are changed so that bert can now work around [@fortawesome/fontawesome#12552](https://github.com/FortAwesome/Font-Awesome/issues/12552).
2. Fix keeping the icons white.
3. Add a `#with` directive so that the `alert` helper only needs to be called once (reducing the reactive cycling).
4. Use a `requestAnimationframe` rather than waiting 20ms.

