### PR TITLE
fix: allow any version of jquery as dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,7 +14,7 @@ Package.onUse(function (api) {
       "ecmascript",
       "templating",
       "session",
-      "jquery@3.0.0",
+      "jquery",
       "fourseven:scss@4.12.0",
     ],
     "client"


### PR DESCRIPTION
this allows Bert to be used also with jquery 1 and 2