### PR TITLE
refactor: bert has weak dependency on jQuery

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "indent": ["error", 2]
+  }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,0 @@
-{
-  "esnext": true
-}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Bert.alert({
   type: 'info',
   style: 'growl-top-right',
   icon: 'fas fa-music'
+  hideDelay: 60 * 60 * 1000
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Bert is a client side, multi-style alerts system for Meteor.
 5. License
 
 #### Installation
+Bert has a weak dependency on jQuery (similar as Blaze), so you can add jQuery to your Meteor app from a [CDN](https://code.jquery.com/) or a [Meteor package](https://atmospherejs.com/meteor/jquery):
+```
+meteor add jquery
+```
+
 To get Bert into your app, just run the following command from within your project's directory:
 
 ```

--- a/README.md
+++ b/README.md
@@ -51,13 +51,24 @@ Bert.alert( 'Yes, I do Mind!', 'danger', 'growl-top-right' );
 And now in v2.0 we also get the Advanced method...
 
 ```
+// alert with custom hideDelay
 Bert.alert({
   title: 'Now Playing',
   message: 'Ernie &mdash; Rubber Duckie',
   type: 'info',
   style: 'growl-top-right',
-  icon: 'fas fa-music'
-  hideDelay: 60 * 60 * 1000
+  icon: 'fas fa-music',
+  hideDelay: 5000,
+});
+
+// permanent alert without any hide delay
+Bert.alert({
+  title: 'Now Playing',
+  message: 'Ernie &mdash; Rubber Duckie',
+  type: 'info',
+  style: 'growl-top-right',
+  icon: 'fas fa-music',
+  permanent: true, // alert stays open without hideDelay
 });
 ```
 
@@ -100,6 +111,8 @@ If you'd like (recommended), you can set any of the values above as defaults, al
 Bert.defaults = {
   hideDelay: 3500,
   // Accepts: a number in milliseconds.
+  permanent: false,
+  // Accepts: boolean
   style: 'fixed-top',
   // Accepts: fixed-top, fixed-bottom, growl-top-left,   growl-top-right,
   // growl-bottom-left, growl-bottom-right.

--- a/bert.js
+++ b/bert.js
@@ -30,7 +30,7 @@ class BertAlert {
     this.defaults = {
       hideDelay: 3500,
       permanent: false,
-      style: 'fixed-top',
+      style: 'growl-top-right',
       type: 'default',
     };
   }

--- a/bert.js
+++ b/bert.js
@@ -51,7 +51,7 @@ class BertAlert {
     this.registerClickHandler();
     this.setBertOnSession(alert);
     requestAnimationFrame(() => this.show());
-    this.bertTimer();
+    this.bertTimer(alert);
   }
 
   registerClickHandler() {
@@ -60,10 +60,10 @@ class BertAlert {
       .on('click', () => this.hide());
   }
 
-  bertTimer() {
+  bertTimer(alert) {
     clearTimeout(this.timer);
-    this.timer = setTimeout(() => this.hide(), this.defaults.hideDelay);
-    return this.timer;
+    const hideDelay = ((typeof alert[0] === 'object') && alert[0].hideDelay) || this.defaults.hideDelay;
+    this.timer = setTimeout(() => this.hide(), hideDelay);
   }
 
   show() {

--- a/bert.js
+++ b/bert.js
@@ -55,8 +55,9 @@ class BertAlert {
   }
 
   registerClickHandler() {
-    $('.bert-alert').off('click');
-    $('.bert-alert').on('click', () => this.hide());
+    $('.bert-alert')
+      .off('click')
+      .on('click', () => this.hide());
   }
 
   bertTimer() {
@@ -75,7 +76,6 @@ class BertAlert {
     $('.bert-alert').removeClass('animate');
     setTimeout(() => {
       $('.bert-alert').removeClass('show');
-      $('.bert-icon').remove();
       Session.set('bertAlert', null);
     }, 300);
   }
@@ -83,24 +83,22 @@ class BertAlert {
   setBertOnSession(alert) {
     if (typeof alert[0] === 'object') {
       const type = alert[0].type || this.defaults.type;
-      const icon = alert[0].icon || this.icons[type];
 
       Session.set('bertAlert', {
         title: alert[0].title || '',
         message: alert[0].message || '',
         type,
         style: alert[0].style || this.defaults.style,
-        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`,
+        icon: alert[0].icon || this.icons[type],
       });
     } else {
       const type = alert[1] || this.defaults.type;
-      const icon = alert[3] || this.icons[type];
 
       Session.set('bertAlert', {
         message: alert[0] || '',
         type,
         style: alert[2] || this.defaults.style,
-        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`,
+        icon: alert[3] || this.icons[type],
       });
     }
   }

--- a/bert.js
+++ b/bert.js
@@ -1,3 +1,5 @@
+/* globals requestAnimationFrame */
+
 class BertAlert {
   constructor() {
     this.styles = [
@@ -32,12 +34,12 @@ class BertAlert {
     };
   }
 
-  alert() {
+  alert(...args) {
     if (this.isVisible()) {
       this.hide();
-      setTimeout(() => this.handleAlert(arguments), 300);
+      setTimeout(() => this.handleAlert(args), 300);
     } else {
-      this.handleAlert(arguments);
+      this.handleAlert(args);
     }
   }
 
@@ -104,4 +106,5 @@ class BertAlert {
   }
 }
 
+// eslint-disable-next-line no-global-assign
 Bert = new BertAlert();

--- a/bert.js
+++ b/bert.js
@@ -29,6 +29,7 @@ class BertAlert {
 
     this.defaults = {
       hideDelay: 3500,
+      permanent: false,
       style: 'fixed-top',
       type: 'default',
     };
@@ -62,8 +63,14 @@ class BertAlert {
 
   bertTimer(alert) {
     clearTimeout(this.timer);
-    const hideDelay = ((typeof alert[0] === 'object') && alert[0].hideDelay) || this.defaults.hideDelay;
-    this.timer = setTimeout(() => this.hide(), hideDelay);
+    let { hideDelay, permanent } = this.defaults;
+
+    if (typeof alert[0] === 'object') {
+      ([{ hideDelay, permanent }] = alert);
+    }
+    if (!permanent) {
+      this.timer = setTimeout(() => this.hide(), hideDelay);
+    }
   }
 
   show() {

--- a/bert.js
+++ b/bert.js
@@ -6,7 +6,7 @@ class BertAlert {
       'growl-top-left',
       'growl-top-right',
       'growl-bottom-left',
-      'growl-bottom-right'
+      'growl-bottom-right',
     ];
 
     this.types = [
@@ -14,7 +14,7 @@ class BertAlert {
       'success',
       'info',
       'warning',
-      'danger'
+      'danger',
     ];
 
     this.icons = {
@@ -22,83 +22,83 @@ class BertAlert {
       success: 'fas fa-check',
       info: 'fas fa-info',
       warning: 'fas fa-exclamation-triangle',
-      danger: 'fas fa-times'
+      danger: 'fas fa-times',
     };
 
     this.defaults = {
       hideDelay: 3500,
       style: 'fixed-top',
-      type: 'default'
+      type: 'default',
     };
   }
 
   alert() {
-    if ( this.isVisible() ) {
+    if (this.isVisible()) {
       this.hide();
-      setTimeout( () => { this.handleAlert( arguments ); }, 300 );
+      setTimeout(() => this.handleAlert(arguments), 300);
     } else {
-      this.handleAlert( arguments );
+      this.handleAlert(arguments);
     }
   }
 
   isVisible() {
-    return $( '.bert-alert' ).hasClass( 'show' );
+    return $('.bert-alert').hasClass('show');
   }
 
-  handleAlert( alert ) {
+  handleAlert(alert) {
     this.registerClickHandler();
-    this.setBertOnSession( alert );
+    this.setBertOnSession(alert);
     requestAnimationFrame(() => this.show());
     this.bertTimer();
   }
 
   registerClickHandler() {
-    $( '.bert-alert' ).off( 'click' );
-    $( '.bert-alert' ).on( 'click', () => { this.hide(); } );
+    $('.bert-alert').off('click');
+    $('.bert-alert').on('click', () => this.hide());
   }
 
   bertTimer() {
-    clearTimeout( this.timer );
-    this.timer = setTimeout( () => { this.hide(); }, this.defaults.hideDelay );
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.hide(), this.defaults.hideDelay);
     return this.timer;
   }
 
   show() {
-    $( '.bert-alert' ).addClass( 'show' ).delay( 25 ).queue( () => {
-      $( '.bert-alert' ).addClass( 'animate' ).dequeue();
+    $('.bert-alert').addClass('show').delay(25).queue(() => {
+      $('.bert-alert').addClass('animate').dequeue();
     });
   }
 
   hide() {
-    $( '.bert-alert' ).removeClass( 'animate' );
-    setTimeout( () => {
-      $( '.bert-alert' ).removeClass( 'show' );
-      $( '.bert-icon').remove();
-      Session.set( 'bertAlert', null );
-    }, 300 );
+    $('.bert-alert').removeClass('animate');
+    setTimeout(() => {
+      $('.bert-alert').removeClass('show');
+      $('.bert-icon').remove();
+      Session.set('bertAlert', null);
+    }, 300);
   }
 
-  setBertOnSession( alert ) {
-    if ( typeof alert[0] === 'object' ) {
-      let type = alert[0].type || this.defaults.type;
-      const icon = alert[0].icon || this.icons[ type ];
+  setBertOnSession(alert) {
+    if (typeof alert[0] === 'object') {
+      const type = alert[0].type || this.defaults.type;
+      const icon = alert[0].icon || this.icons[type];
 
-      Session.set( 'bertAlert', {
-        title: alert[0].title || "",
-        message: alert[0].message || "",
-        type: type,
+      Session.set('bertAlert', {
+        title: alert[0].title || '',
+        message: alert[0].message || '',
+        type,
         style: alert[0].style || this.defaults.style,
-        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`
+        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`,
       });
     } else {
-      let type = alert[1] || this.defaults.type;
-      const icon = alert[3] || this.icons[ type ];
+      const type = alert[1] || this.defaults.type;
+      const icon = alert[3] || this.icons[type];
 
-      Session.set( 'bertAlert', {
-        message: alert[0] || "",
-        type: type,
+      Session.set('bertAlert', {
+        message: alert[0] || '',
+        type,
         style: alert[2] || this.defaults.style,
-        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`
+        icon: `<div class="bert-icon"><i class="${icon}"></i></div>`,
       });
     }
   }

--- a/bert.js
+++ b/bert.js
@@ -18,11 +18,11 @@ class BertAlert {
     ];
 
     this.icons = {
-      default: 'fas fa-bell',
-      success: 'fas fa-check',
-      info: 'fas fa-info',
-      warning: 'fas fa-exclamation-triangle',
-      danger: 'fas fa-times',
+      default: 'fa-solid fa-bell',
+      success: 'fa-solid fa-check',
+      info: 'fa-solid fa-circle-info',
+      warning: 'fa-solid fa-triangle-exclamation',
+      danger: 'fa-solid fa-xmark',
     };
 
     this.defaults = {

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: "themeteorchef:bert",
-  version: "2.2.2",
+  name: "jirikrepl:bert",
+  version: "2.2.3",
   summary: "A client side, multi-style alerts system for Meteor.",
-  git: "http://github.com/themeteorchef/bert",
+  git: "https://github.com/jirikrepl/bert",
   documentation: "README.md",
 });
 
@@ -10,7 +10,7 @@ Package.onUse(function (api) {
   api.versionsFrom("1.2.0.2");
 
   api.use(
-    ["ecmascript", "templating", "session", "fourseven:scss@4.12.0"],
+    ["ecmascript", "templating", "session", "fourseven:scss@4.14.2"],
     "client"
   );
 

--- a/package.js
+++ b/package.js
@@ -10,9 +10,11 @@ Package.onUse(function (api) {
   api.versionsFrom("1.2.0.2");
 
   api.use(
-    ["ecmascript", "templating", "session", "jquery", "fourseven:scss@4.12.0"],
+    ["ecmascript", "templating", "session", "fourseven:scss@4.12.0"],
     "client"
   );
+
+  api.use("jquery", "client", { weak: true });
 
   api.addFiles(
     [

--- a/stylesheets/bert.scss
+++ b/stylesheets/bert.scss
@@ -31,7 +31,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
   float: left;
   width: 32px;
   height: 32px;
-  background: rgba( 0, 0, 0, 0.2 );
+  background: rgba(0, 0, 0, 0.10);
   border-radius: 3px;
   margin-right: 15px;
 
@@ -87,7 +87,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
 .bert-alert.success,
 .bert-alert.info,
 .bert-alert.danger {
-  p, i { color: #fff; }
+  p, i { color: #333; }
 }
 
 .bert-alert.warning {
@@ -139,7 +139,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
   }
 
   .bert-content p {
-    font-size: 14px;
+    font-size: 16px;
     width: 100%;
   }
 }

--- a/stylesheets/bert.scss
+++ b/stylesheets/bert.scss
@@ -31,7 +31,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
   float: left;
   width: 32px;
   height: 32px;
-  background: rgba( 0, 0, 0, 0.30 );
+  background: rgba( 0, 0, 0, 0.2 );
   border-radius: 3px;
   margin-right: 15px;
 

--- a/stylesheets/bert.scss
+++ b/stylesheets/bert.scss
@@ -37,7 +37,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
 
   i {
     position: relative;
-    top: 0px;
+    top: 0;
     font-size: 16px;
     line-height: 16px;
   }
@@ -48,7 +48,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
   width: calc( 100% - 47px );
 
   h5 + p {
-    top: 0px;
+    top: 0;
   }
 
   p {
@@ -60,7 +60,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
 .bert-alert .bert-content > h5 {
   display: block;
   color: $black-2;
-  margin: 0px 0px 5px;
+  margin: 0 0 5px;
   font-size: 14px;
 }
 
@@ -86,9 +86,12 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
 
 .bert-alert.success,
 .bert-alert.info,
-.bert-alert.warning,
 .bert-alert.danger {
   p, i { color: #fff; }
+}
+
+.bert-alert.warning {
+  p, i { color: $black-0; }
 }
 
 .bert-alert.success { background: $green; }
@@ -98,8 +101,8 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
 
 .bert-alert.fixed-top,
 .bert-alert.fixed-bottom {
-  left: 0px;
-  right: 0px;
+  left: 0;
+  right: 0;
 }
 
 .bert-alert.fixed-top {
@@ -131,7 +134,7 @@ $transition: cubic-bezier( 0.500, -0, 0.275, 1.110 );
   .bert-content h5 {
     display: block;
     color: #fff;
-    margin: 0px 0px 5px;
+    margin: 0 0 5px;
     font-size: 14px;
   }
 

--- a/stylesheets/colors.scss
+++ b/stylesheets/colors.scss
@@ -1,7 +1,7 @@
-$red:      #da5347;
-$green:    #75ba50;
-$blue:     #1b9edb;
-$yellow:   #fad131;
+$red:      #e94d4d;
+$green:    #59c73d;
+$blue:     #5bc0de;
+$yellow:   #ffbb00;
 $black-0:  #333333;
 $black-1:  #444444;
 $black-2:  #666666;

--- a/stylesheets/colors.scss
+++ b/stylesheets/colors.scss
@@ -1,7 +1,7 @@
-$red:      #e94d4d;
-$green:    #59c73d;
-$blue:     #5bc0de;
-$yellow:   #ffbb00;
+$red:      #FFB4AE;
+$green:    #AEFFB6;
+$blue:     #B4CEFF;
+$yellow:   #FFE9AD;
 $black-0:  #333333;
 $black-1:  #444444;
 $black-2:  #666666;

--- a/templates/bert-alert.html
+++ b/templates/bert-alert.html
@@ -3,7 +3,7 @@
   <div class="bert-alert {{a.style}} {{a.type}} clearfix">
     <div class="bert-container">
       <div class="bert-gem">
-        {{{a.icon}}}
+          <i class="{{a.icon}}"></i>
       </div>
       <div class="bert-content">
         {{#if a.title}}<h5>{{a.title}}</h5>{{/if}}

--- a/templates/bert-alert.js
+++ b/templates/bert-alert.js
@@ -1,3 +1,5 @@
 Template.bertAlert.helpers({
-  alert() { return Session.get( 'bertAlert' ); }
+  alert() {
+    return Session.get('bertAlert');
+  },
 });


### PR DESCRIPTION
Now we are able to add jQuery from CDN directly to `<head>`. 
jQuery does not need to be part of the initial JS bundle (and users might have it cached already)